### PR TITLE
Add a replace to remove commas from currencies that support it

### DIFF
--- a/playstation_purchases.py
+++ b/playstation_purchases.py
@@ -21,7 +21,9 @@ def calculate_product_purchase_total(entries, currency_symbol):
                 # 'wallet funding' transactions are not counted, as this would result in the doubling of certain purchase totals
             elif line.startswith(currency_symbol):
                 if current_transaction_type == 'product_purchase':
-                    currency_total += float(line[1:])
+                    # For currencies that use commas to separate thousands, remove the commas
+                    number_without_comma = line[1:].replace(",", "")
+                    currency_total += float(number_without_comma)
                     transaction_count += 1
                     current_transaction_type = None
 


### PR DESCRIPTION
My Playstation history is made up of Indian currencies, which uses the `Rs 3,456` notation of separating thousands which the others don't or more likely that no singular purchase is going to be in the 1000s for pounds, euros, dollars.

So adding a replace function to remove the `,` before you run a float conversion on it

Something like this

```
11/20/2023
Product Purchase
Rs 3,359
```

I still needed to do a replace all `Rs` with `$` since the line split caused issues, but this should take care of the comma problem at the very least